### PR TITLE
Fix fault address

### DIFF
--- a/startup.c
+++ b/startup.c
@@ -42,7 +42,7 @@ static int zeroed_variable_in_bss;
 static int initialized_variable_in_data = 42;
 
 extern void main(void);
-void __attribute__((section(".init"))) _reset(void) {
+void __attribute__((section(".init"),naked)) _reset(void) {
     register uint32_t *src, *dst;
     asm volatile("la gp, _global_pointer");
     asm volatile("la sp, _end_stack");

--- a/vector.S
+++ b/vector.S
@@ -9,10 +9,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -147,7 +147,7 @@ trap_vmsi:
 
 trap_vmti:
   trap_entry
-  jal isr_vmsi
+  jal isr_vmti
   trap_exit
 
 trap_vmei:


### PR DESCRIPTION
First instructions generated on disassembly code refers to stack allocation on an invalid address, with naked attribute you avoid those constructions under _reset. 